### PR TITLE
Switch first row to 50/50 on "tablet" viewport

### DIFF
--- a/src/_layouts/home.erb
+++ b/src/_layouts/home.erb
@@ -10,7 +10,7 @@ layout: default
 </section>
 
 <section class="section columns">
-    <div class="column is-three-fifths">
+    <div class="column is-three-fifths-desktop is-half-tablet">
       <article class="box">
         <h1 class="title is-4"><%= data.title %></h1>
         <img src="<%= data.image %>">
@@ -20,7 +20,7 @@ layout: default
       </article>
     </div>
 
-    <div class="column is-two-fifths">
+    <div class="column is-two-fifths-desktop is-half-tablet">
       <% site.data.highlights.each do |highlight| %>
         <%= render "highlight", highlight: highlight %>
       <% end %>


### PR DESCRIPTION
As the viewport shrinks, the two columns should switch from 60/40 to 50/50. This currently uses the bulma sizing of "tablet", but it should probably shrink a bit before that: consider making the tablet viewport size larger.