### PR TITLE
Keep link to Filterameter post on one line

### DIFF
--- a/src/_data/highlights.yml
+++ b/src/_data/highlights.yml
@@ -13,8 +13,8 @@
   message_header_class: has-text-white
   logo: rubygems_logo_red.png
   description: |
-    Simplify and speed development of Rails controllers by making filter parameters declarative with [the Filterameter
-    gem](/posts/filterameter).
+    Simplify and speed development of Rails controllers by making filter parameters declarative
+    with [the Filterameter gem](/posts/filterameter).
 
     With the look and feel of a Rails DSL, declare filters and sorts for search pages. The next developer in (hey, maybe 
     that's you!) will thank you. It's obvious what filter parameters are available and easy to add more.


### PR DESCRIPTION
The raw page source showed the link split across two lines. Not sure if that matters, but it still did not seem to get indexed.

**Before**
```
<p>Simplify and speed development of Rails controllers by making filter parameters declarative with <a href="/posts/filterameter">the Filterameter
gem</a>.</p>
```

**After**
```
<p>Simplify and speed development of Rails controllers by making filter parameters declarative
with <a href="/posts/filterameter">the Filterameter gem</a>.</p>
```