### PR TITLE
Add sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,5 @@ gem "puma", "< 7"
 
 # Or for faster parsing of HTML-only resources via Inspectors, use Nokolexbor:
 # gem "nokolexbor", "~> 0.4"
+
+gem "bridgetown-sitemap", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       zeitwerk (~> 2.5)
     bridgetown-paginate (1.3.4)
       bridgetown-core (= 1.3.4)
+    bridgetown-sitemap (2.0.2)
+      bridgetown (>= 1.2.0, < 2.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -135,6 +137,7 @@ PLATFORMS
 
 DEPENDENCIES
   bridgetown (~> 1.3.4)
+  bridgetown-sitemap (~> 2.0)
   puma (< 7)
 
 BUNDLED WITH

--- a/config/initializers.rb
+++ b/config/initializers.rb
@@ -60,4 +60,7 @@ Bridgetown.configure do |config|
 
   # For more documentation on how to configure your site using this initializers file,
   # visit: https://edge.bridgetownrb.com/docs/configuration/initializers/
+
+  # https://github.com/ayushn21/bridgetown-sitemap
+  init :"bridgetown-sitemap"
 end

--- a/src/404.html
+++ b/src/404.html
@@ -1,6 +1,7 @@
 ---
 permalink: /404.html
 layout: default
+sitemap: false
 ---
 
 <h1>404</h1>

--- a/src/500.html
+++ b/src/500.html
@@ -1,6 +1,7 @@
 ---
 permalink: /500.html
 layout: default
+sitemap: false
 ---
 
 <h1>500</h1>

--- a/src/about.md
+++ b/src/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About
+sitemap: false
 ---
 
 This is the basic Bridgetown site template. You can find out more info about customizing your Bridgetown site, as well as basic Bridgetown usage documentation at [bridgetownrb.com](https://bridgetownrb.com/)

--- a/src/posts.md
+++ b/src/posts.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Posts
+sitemap: false
 ---
 
 <section class="section">


### PR DESCRIPTION
I added `sitemap: false` to the error pages as well as the about and posts index page. If the latter get updated and are ready for prime time, the flag should be removed.